### PR TITLE
#7789 Prevent gird config being submitted if not valid

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/editconfig.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/grid/dialogs/editconfig.html
@@ -48,6 +48,7 @@
                         type="button"
                         button-style="success"
                         label-key="general_submit"
+                        disabled="gridConfigEditor.$invalid === true"
                         action="vm.submit()">
                     </umb-button>
                 </umb-editor-footer-content-right>


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

Fixes issue: https://github.com/umbraco/Umbraco-CMS/issues/7789

### Description

I have disabled the submit button until JSON is valid.
